### PR TITLE
try NOR before NAND

### DIFF
--- a/src/flashcmd_api.c
+++ b/src/flashcmd_api.c
@@ -32,14 +32,14 @@ long flash_cmd_init(struct flash_cmd *cmd)
 #ifdef EEPROM_SUPPORT
 	if ((eepromsize <= 0) && (mw_eepromsize <= 0) && (seepromsize <= 0)) {
 #endif
-		if ((flen = snand_init()) > 0) {
-			cmd->flash_erase = snand_erase;
-			cmd->flash_write = snand_write;
-			cmd->flash_read  = snand_read;
-		} else if ((flen = snor_init()) > 0) {
+		if ((flen = snor_init()) > 0) {
 			cmd->flash_erase = snor_erase;
 			cmd->flash_write = snor_write;
 			cmd->flash_read  = snor_read;
+		} else if ((flen = snand_init()) > 0) {
+		  cmd->flash_erase = snand_erase;
+		  cmd->flash_write = snand_write;
+		  cmd->flash_read  = snand_read;
 		}
 #ifdef EEPROM_SUPPORT
 	} else if ((eepromsize > 0) || (mw_eepromsize > 0) || (seepromsize > 0)) {


### PR DESCRIPTION
This fixes the detection issue:

before
```
$ build/snander -i

SNANDer - Serial Nor/nAND/Eeprom programmeR v.1.7.8 by McMCC <mcmcc@mail.ru>

Found programmer device: WinChipHead (WCH) - CH341A
Device revision is 3.0.4
spi_nand_probe: mfr_id = 0xc2, dev_id = 0x20, dev_id_2 = 0x17
Get Status Register 1: 0xff
Get Status Register 2: 0xff
Using Flash ECC.
Detected SPI NAND Flash: MXIC MX35LF2G14AC, Flash Size: 256MB, OOB Size: 64B
```
after
```
$ build/snander -i

SNANDer - Serial Nor/nAND/Eeprom programmeR v.1.7.8 by McMCC <mcmcc@mail.ru>

Found programmer device: WinChipHead (WCH) - CH341A
Device revision is 3.0.4
spi device id: c2 20 17 c2 20 (2017c220)
Detected SPI NOR Flash: MX25L6405D, Flash Size: 8 MB
```